### PR TITLE
Creation retries beta fixes #3

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
       "es6": true,
       "node": true
   },
+  parser: 'babel-eslint',
   "extends": "eslint:recommended",
   "parserOptions": {
       "sourceType": "module"
@@ -43,6 +44,7 @@ module.exports = {
         "error",
       ],
       "no-multiple-empty-lines": [
+        "error",
         {"max":2},
       ],
       "no-multi-str": [
@@ -106,16 +108,9 @@ module.exports = {
         "error",
         "last",
       ],
-      "linebreak-style": [
-        "error",
-        "unix",
-      ],
       "eol-last": [
         "error",
         "always",
-      ],
-      "no-multiple-empty-lines": [
-        "error",
       ],
       "no-nested-ternary": [
         "error",
@@ -147,6 +142,10 @@ module.exports = {
       ],
       "arrow-spacing": [
         "error"
+      ],
+      "arrow-parens": [
+        "error",
+        "always"
       ],
       "comma-spacing": [
         "error"

--- a/README.md
+++ b/README.md
@@ -424,9 +424,19 @@ factory.create("salesmanWithStores"); //Infinite loop
 Since the factory *salesmanWithStores* creates a store using the factory *storeWithSalemsman*, which creates a sale using this same factory *salesmanWithStores*, each creation will create one of the other. Hence, this function will never return.
 
 ### Extra configurations
-Configuration file ``config/factory.js``
 #### Loading factories
 #### Unique
-When using the same factory more than one time the models creation might **fail** due to uniqueness issues. This is why we advise you to use **faker** when defining unique attributes. Even by using random data, it can fail by chance. To avoid such errors the creation of a model can be **retried** in case of uniqueness error. The number of times the creation will be retried can be configured in this file, adding ``{creationRetries: times }``, where ``times`` is a number. The default value is **1**.
+When using the same factory more than one time the models creation might **fail** due to uniqueness issues. This is why we advise you to use **faker** when defining unique attributes. Even by using random data, it can fail by chance. To avoid such errors the creation of a model can be **retried** in case of uniqueness error.
+
+The **number** of times the creation will be retried can be configured in `config/local.js`:
+
+```js
+factory: {
+  creationRetries: 3
+}
+```
+
+The default value is **1**.
+
 #### Populated Object
 The object returned after the creation will be populated, in order to refer to its values and associations during tests. To set the depth of this population use the parameter ``{populationDepth: depth }``, where ``depth`` indicates how many times the nested models associations will be populated. The default value is **3**. Note that when having **circular references**, the returned object will be highly populated so we advise you not to use big numbers in this configuration.

--- a/lib/Definition.js
+++ b/lib/Definition.js
@@ -254,6 +254,38 @@ class Definition {
   }
 
   create(saved) {
+    return new Promise(function(resolve, reject) {
+      this.retryCreate(saved)
+        .then(resolve)
+        .catch(reject);
+    }.bind(this));
+  }
+
+  async retryCreate(saved) {
+    const defaultRetries = 4;
+    const creationRetries = typeof sails === 'undefined'
+      ? defaultRetries
+      : _.get(sails, 'config.factory.creationRetries', defaultRetries);
+    let tries = 0;
+    let out;
+    let reason;
+
+    while (tries < creationRetries && !out) {
+      try {
+        out = await this._doCreate(saved);
+      } catch (err) {
+        reason = err;
+        tries++;
+        if (err.name === 'SequelizeUniqueConstraintError') {
+          console.error(`factory retry ${tries}: ${err.parent.detail}`);
+        }
+      }
+    }
+    if (!out) { console.error(err); throw reason; }
+    return out;
+  }
+
+  _doCreate(saved) {
     const isRootCreation = !saved;
     let createdModel;
 

--- a/lib/Definition.js
+++ b/lib/Definition.js
@@ -262,7 +262,7 @@ class Definition {
   }
 
   async retryCreate(saved) {
-    const defaultRetries = 4;
+    const defaultRetries = 1;
     const creationRetries = typeof sails === 'undefined'
       ? defaultRetries
       : _.get(sails, 'config.factory.creationRetries', defaultRetries);

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "sails-hook-fireline": "^5.0.0"
   },
   "devDependencies": {
-    "eslint": "^5.3.0",
+    "babel-eslint": "^10.1.0",
+    "eslint": "^6.8.0",
     "faker": "^4.1.0",
-    "lodash": "^4.17.10",
     "mocha": "^5.2.0",
     "mysql2": "^1.3.6",
     "sails": "^1.0.2",


### PR DESCRIPTION
This is a first attempt to get the feature for creation retries and give developer the chance to configure it using `local.js` in its sails instance.

I did not attempt to fix another styles, documentation or any other issue, just updated eslint and using babel parser, as well other warnings.